### PR TITLE
Revert "Add pageview tracking"

### DIFF
--- a/src/js-setup.js
+++ b/src/js-setup.js
@@ -50,7 +50,6 @@ JsSetup.prototype.init = function (opts) {
 
 		if (flags.get('beacon')) {
 			beacon.init && beacon.init(opts.beacon);
-			beacon.fire('pageview');
 		}
 
 		if (flags.get('welcomePanel')) {


### PR DESCRIPTION
Reverts Financial-Times/next-js-setup#26

Decide against this for now - using dwell instead